### PR TITLE
Add Makefile, change setup and add travis

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,5 +11,8 @@ indent_size = 4
 [*.{js,py}]
 max_line_length = 120
 
-[{package.json,.travis.yml}]
+[{*.json,.travis.yml}]
 indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+python:
+  - "2.7"
+
+services: postgresql
+
+env:
+  - DEBUG=True SECRET_KEY=secret DATABASE_URL=postgres://postgres@localhost/travis_ci_test
+
+install:
+  - make pip
+
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
+  - python manage.py migrate
+
+script:
+  - make validate
+
+branches:
+  only:
+    - master
+    - dev

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: all
+all: start
+
+.PHONY: start
+start:
+	. ./tools/scripts/setup.sh
+
+.PHONY: validate
+validate: lint test
+
+.PHONY: lint
+lint:
+	echo "Linting via PEP8"
+	pep8
+
+.PHONY: test
+test:
+	echo "Testing"
+	python manage.py test
+
+.PHONY: pip
+pip:
+	pip install -r requirements.txt
+
+.PHONY: dev
+dev:
+	python manage.py runserver 5000

--- a/README.md
+++ b/README.md
@@ -1,8 +1,24 @@
 # Spend_ya
 
-This is home of _Spend_Ya_ - Telegram bot for [**_Ya.Hack_**](https://events.yandex.ru/events/meetings/03-2016/). 
+This is home of _Spend_Ya_ - Telegram bot for [**_Ya.Hack_**](https://events.yandex.ru/events/meetings/03-2016/).
 
 P.S. Please, **do not tell him** that he is just a bot, he will never forgive you that :smirk:
+
+## Setup
+
+```sh
+make
+# Then activate virtual environment by instruction in output
+# For Linux or OS X:
+. venv/bin/activate
+# For Windows (under Cygwin)
+venv/Scripts/activate.bat
+# For Windows (under Mingw)
+. venv/Scripts/activate
+
+# Then install requirements
+make pip
+```
 
 ## Running locally
 
@@ -24,6 +40,20 @@ $ python manage.py runserver 0.0.0.0:5000
 ```
 
 Your app should now be running on [localhost:5000](http://localhost:5000/).
+
+### Deactivation virtual environment
+
+For deactivate virtual environment follow next command:
+
+```sh
+deactivate
+```
+
+If it doesn't work, try with `source`:
+
+```sh
+source deactivate
+```
 
 
 ## Documentation

--- a/app.json
+++ b/app.json
@@ -3,5 +3,17 @@
   "description": "Telegram bot for Ya.Money.",
   "repository": "https://github.com/banditi/spend-ya",
   "keywords": ["python", "django", "yandex" ],
-  "addons": [ "heroku-postgresql" ]
+  "addons": [ "heroku-postgresql" ],
+  "env": {
+    "DEBUG": "True",
+    "SECRET_KEY": {
+      "generator": "secret"
+    },
+    "TELEGRAM_TOKEN_ID": {
+      "required": true
+    }
+  },
+  "scripts": {
+    "postdeploy": "python manage.py migrate"
+  }
 }

--- a/spend_ya_money/tests.py
+++ b/spend_ya_money/tests.py
@@ -1,3 +1,10 @@
 from django.test import TestCase
 
-# Create your tests here.
+from .models import YaMoney
+
+
+class YaMoneyMethodTests(TestCase):
+
+    def test_date(self):
+        wallet = YaMoney(account=134, access_token='secret')
+        self.assertEqual(wallet.created_at, wallet.updated_at)

--- a/spend_ya_project/config.example.py
+++ b/spend_ya_project/config.example.py
@@ -1,5 +1,6 @@
 # Your secret key from settings.py
 SECRET_KEY = 'SECRET_KEY'
+DEBUG = True
 
 # Change USER, LOGIN, HOST, PORT, DB_NAME for your values
 DATABASE_URL = 'postgres://USER:LOGIN@HOST:PORT/DB_NAME'

--- a/spend_ya_project/settings.py
+++ b/spend_ya_project/settings.py
@@ -13,22 +13,16 @@ import os
 import dj_database_url
 
 try:
-    from config import DATABASE_URL, SECRET_KEY
+    from config import DATABASE_URL, SECRET_KEY, DEBUG
 except ImportError:
+    DEBUG = os.environ.get('DEBUG', False)
     DATABASE_URL = ''
-    SECRET_KEY = os.environ['SECRET_KEY']
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'secret')
 
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
-
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
 
 
 # Application definition

--- a/tools/scripts/pre-commit.sh
+++ b/tools/scripts/pre-commit.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# * Check changed py files using pep8.
+
+PATCH_FILE="working-tree.patch"
+
+function cleanup {
+    exit_code=$?
+    if [ -f "${PATCH_FILE}" ]; then
+        git apply "${PATCH_FILE}" 2> /dev/null
+        rm "${PATCH_FILE}"
+    fi
+    exit ${exit_code}
+}
+
+trap cleanup EXIT SIGINT SIGHUP
+
+# Cancel any changes to the working tree that are not going to be committed
+git diff > "${PATCH_FILE}"
+git checkout -- .
+
+git_cached_files=$(git diff --cached --name-only --diff-filter=ACMR | grep "\.py$")
+if [ "${git_cached_files}" ]; then
+    make validate || exit 1
+fi

--- a/tools/scripts/setup.sh
+++ b/tools/scripts/setup.sh
@@ -1,32 +1,41 @@
 #!/bin/bash
 # heroku create
-ACTIVATE_VIRT=""
-OS=$1
-echo $OS
-if [ $OS != "Win" ] && [ $OS != "Linux" ] && [ $OS != "OSX" ]
+OS=$( uname -s )
+if [[ -z ${OS} ]];
 then
-    printf  "Please, type name of your OS from one of the following: OSX, Win or Linux \n NOTE: input argument is case-sensitive!"
-    exit
-fi
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-ROOT_APP_DIR="$( cd "$( cd ../..)" && pwd )"
-
-RESULT=$( virtualenv --version)
-echo "Virtualenv has $RESULT version"
-if [ $RESULT ]
-then
-    virtualenv venv;
-    case "$OS" in 
-        "OSX" ) $( source venv/bin/activate );;
-        "Linux" ) $( source venv/bin/activate );;
-        "Win" ) $( venv/Scripts/activate.bat );;
-    esac
-        
+    echo "Sorry, but we cannot get your OS."
+    echo "Let's try the virtual environment by yourself."
+    return 1;
 else
-    echo "Install virtualenv please"
+    echo "Your OS: ${OS}"
 fi
 
-pip install -r requirements.txt;
+# Add git-hook
+$( ln -fs ../../tools/scripts/pre-commit.sh .git/hooks/pre-commit )
+$( chmod +x .git/hooks/pre-commit )
 
-printf "Setup of evnironment is finished"
+RESULT=$( virtualenv --version )
+if [ ${RESULT} ]
+then
+    echo "Virtualenv has $RESULT version"
+    virtualenv venv;
+else
+    echo "Installing virtualenv."
+    pip install virtualenv
+fi
+
+echo "To activate the virtual environment run following command:"
+case ${OS} in
+    Darwin*|Linux*)
+        echo ">> . venv/bin/activate"
+        ;;
+    CYGWIN*|MSYS*)
+        echo ">> venv/Scripts/activate.bat"
+        ;;
+    MINGW32*)
+        echo ">> . venv/Scripts/activate"
+        ;;
+    *)
+        echo ">> Try googling... :("
+        ;;
+esac


### PR DESCRIPTION
## Makefile

Добавил `Makefile` для упрощения запуска команд:
- `make` – запускает `venv`, устанавливает зависимости и производит валидацию.
  - `make start` – запускает `tools/scripts/setup.sh`.
  - `make lint` – линтирует `*.py` файлы по спецификации PEP8.
  - `make pip` – установка зависимостей (запускать если уже запущен `venv`).
## Travis

Добавил настройки для [travis](https://travis-ci.org/). Добавил пока для валидации кода при пул рекветов. [Вот](https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle) полное описания цикла сборки. Я использую `script` для запуска валидации. Если PEP8 находит ошибки или не проходят тесты, то пул реквест будет помечен как `Failed`.
